### PR TITLE
disabled lifecycle of s3 bucket for front50

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -45,7 +45,7 @@ resource "aws_s3_bucket" "storage" {
 
   lifecycle_rule {
     id      = "${local.name}"
-    enabled = true
+    enabled = false
 
     tags = {
       "rule"      = "transit the current version object to IA after 90 days"


### PR DESCRIPTION
make sure a lifecycle rule does not delete the objects of pipelines/applications configuration