### PR TITLE
Dynamic policy attachments in IRSA module

### DIFF
--- a/modules/iam-role-for-serviceaccount/main.tf
+++ b/modules/iam-role-for-serviceaccount/main.tf
@@ -26,7 +26,9 @@ resource "aws_iam_role" "irsa" {
 }
 
 resource "aws_iam_role_policy_attachment" "irsa" {
-  for_each   = toset(var.enabled ? var.policy_arns : [])
+  for_each = {
+    for key, val in var.policy_arns : key => val
+  }
   policy_arn = each.value
   role       = aws_iam_role.irsa[0].name
 }


### PR DESCRIPTION
(fix) changed to use built values from configuration, not remote state when working with for_each