### PR TITLE
IRSA role creation condition bug fix

### DIFF
--- a/examples/spinnaker-managed-eks/main.tf
+++ b/examples/spinnaker-managed-eks/main.tf
@@ -20,6 +20,7 @@ module "spinnaker-managed-eks" {
   kubernetes_version         = "1.17"
   enabled_cluster_log_types  = ["api", "audit"]
   container_insights_enabled = true
+  app_mesh_enabled           = true
   node_groups = {
     default = {
       min_size      = 1

--- a/modules/iam-role-for-serviceaccount/main.tf
+++ b/modules/iam-role-for-serviceaccount/main.tf
@@ -26,9 +26,7 @@ resource "aws_iam_role" "irsa" {
 }
 
 resource "aws_iam_role_policy_attachment" "irsa" {
-  for_each = {
-    for key, val in var.policy_arns : key => val
-  }
+  for_each   = var.enabled ? { for key, val in var.policy_arns : key => val } : {}
   policy_arn = each.value
   role       = aws_iam_role.irsa[0].name
 }


### PR DESCRIPTION
Added empty map condition to the `for_each` loop for policy attachment resources. Because those are not required when a user configured to disable IRSA module.

example:
```
module "irsa" {
  enabled = false
}
```