### PR TITLE
feat(s3): public access block policy for s3 buckets

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -120,7 +120,8 @@ resource "aws_route_table_association" "public" {
 
 # vpc endpoints
 data "aws_vpc_endpoint_service" "s3" {
-  service = "s3"
+  service      = "s3"
+  service_type = "Gateway"
 }
 
 resource "aws_vpc_endpoint" "s3" {

--- a/storage.tf
+++ b/storage.tf
@@ -40,6 +40,14 @@ resource "aws_iam_role_policy_attachment" "spin-s3admin" {
   role       = module.eks.role.name
 }
 
+resource "aws_s3_bucket_public_access_block" "storage" {
+  bucket                  = aws_s3_bucket.storage.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket" "storage" {
   bucket = local.name
   tags   = var.tags
@@ -80,6 +88,14 @@ resource "aws_iam_policy" "artifact-write" {
     }]
     Version = "2012-10-17"
   })
+}
+
+resource "aws_s3_bucket_public_access_block" "artifact" {
+  bucket                  = aws_s3_bucket.artifact.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 resource "aws_s3_bucket" "artifact" {


### PR DESCRIPTION
terraform plan:

```
Terraform will perform the following actions:

  # module.spinnaker.aws_s3_bucket_public_access_block.artifact will be created
  + resource "aws_s3_bucket_public_access_block" "artifact" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = "spinnaker-dev-tc1-xxxxx-artifact"
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = true
    }

  # module.spinnaker.aws_s3_bucket_public_access_block.storage will be created
  + resource "aws_s3_bucket_public_access_block" "storage" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = "spinnaker-dev-tc1-xxxxx"
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = true
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```