### PR TITLE
fix(spinnaker): helm vars

### DIFF
--- a/examples/spinnaker/main.tf
+++ b/examples/spinnaker/main.tf
@@ -31,6 +31,7 @@ module "spinnaker" {
   helm = {
     vars = {
       "halyard.spinnakerVersion" = "1.27.0"
+      "halyard.image.tag"        = "1.44.0"
     }
   }
 }

--- a/examples/spinnaker/main.tf
+++ b/examples/spinnaker/main.tf
@@ -13,8 +13,7 @@ provider "aws" {
 
 # spinnaker
 module "spinnaker" {
-  source                 = "Young-ook/spinnaker/aws"
-  version                = "~> 2.0"
+  source                 = "../../"
   name                   = var.name
   stack                  = var.stack
   detail                 = var.detail
@@ -29,6 +28,11 @@ module "spinnaker" {
   aurora_instances       = var.aurora_instances
   s3_bucket              = var.s3_bucket
   assume_role_arn        = [module.spinnaker-managed-role.role_arn]
+  helm = {
+    vars = {
+      "halyard.spinnakerVersion" = "1.27.0"
+    }
+  }
 }
 
 # spinnaker managed role

--- a/main.tf
+++ b/main.tf
@@ -166,20 +166,12 @@ resource "helm_release" "spinnaker" {
 
   # value block with custom values to be merged with the values yaml
   dynamic "set" {
-    for_each = lookup(var.helm, "values", {})
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = {
+    for_each = merge({
       "minio.enabled" = "false"
       "s3.enabled"    = "true"
       "s3.bucket"     = module.s3.bucket.id
       "s3.region"     = module.current.region.id
-    }
+    }, lookup(var.helm, "vars", {}))
     content {
       name  = set.key
       value = set.value


### PR DESCRIPTION
Support for selecting a specific halyard version

```
 Containers:
   halyard:
    Image:        us-docker.pkg.dev/spinnaker-community/docker/halyard:1.44.0
    Port:         8064/TCP
    Host Port:    0/TCP
    Environment:  <none>
    Mounts:
      /home/spinnaker from halyard-home (rw)
      /opt/halyard/config from halyard-config (rw)
      /opt/registry/passwords from reg-secrets (rw)
```